### PR TITLE
feat: environment-based API keys for example app

### DIFF
--- a/example/sqflite_supabase_example/.gitignore
+++ b/example/sqflite_supabase_example/.gitignore
@@ -41,3 +41,7 @@ app.*.map.json
 /android/app/debug
 /android/app/profile
 /android/app/release
+
+# Environment files
+.env
+.env.*

--- a/example/sqflite_supabase_example/README.md
+++ b/example/sqflite_supabase_example/README.md
@@ -1,16 +1,38 @@
 # sqflite_supabase_example
 
-A new Flutter project.
+A Flutter example app demonstrating offline-first CRUD with Supabase sync using the talon package.
 
-## Getting Started
+## Setup
 
-This project is a starting point for a Flutter application.
+### 1. Get your Supabase credentials
 
-A few resources to get you started if this is your first Flutter project:
+From your [Supabase dashboard](https://supabase.com/dashboard), copy:
+- **Project URL** (e.g. `https://abc123.supabase.co`)
+- **Anon public key** (found under Settings > API)
 
-- [Lab: Write your first Flutter app](https://docs.flutter.dev/get-started/codelab)
-- [Cookbook: Useful Flutter samples](https://docs.flutter.dev/cookbook)
+### 2. Run the app
 
-For help getting started with Flutter development, view the
-[online documentation](https://docs.flutter.dev/), which offers tutorials,
-samples, guidance on mobile development, and a full API reference.
+Pass your credentials via `--dart-define`:
+
+```bash
+flutter run -d chrome \
+  --dart-define=SUPABASE_URL=https://your-project.supabase.co \
+  --dart-define=SUPABASE_ANON_KEY=your-anon-key
+```
+
+If you omit the credentials, the app will show a helpful error screen with instructions.
+
+### 3. Optional: use a dart-define file
+
+To avoid typing keys each time, create a `.env` file (git-ignored):
+
+```
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+```
+
+Then run:
+
+```bash
+flutter run -d chrome --dart-define-from-file=.env
+```

--- a/example/sqflite_supabase_example/lib/main.dart
+++ b/example/sqflite_supabase_example/lib/main.dart
@@ -13,6 +13,29 @@ import 'talon_implementation/talon_implementation.dart';
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
+  if (supabaseUrl.isEmpty || supabaseKey.isEmpty) {
+    runApp(
+      const MaterialApp(
+        home: Scaffold(
+          body: Center(
+            child: Padding(
+              padding: EdgeInsets.all(32),
+              child: Text(
+                'Missing Supabase configuration.\n\n'
+                'Run with:\n'
+                'flutter run -d chrome \\\n'
+                '  --dart-define=SUPABASE_URL=your-url \\\n'
+                '  --dart-define=SUPABASE_ANON_KEY=your-key',
+                textAlign: TextAlign.center,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    return;
+  }
+
   await Supabase.initialize(
     url: supabaseUrl,
     anonKey: supabaseKey,

--- a/example/sqflite_supabase_example/lib/talon_implementation/config.dart
+++ b/example/sqflite_supabase_example/lib/talon_implementation/config.dart
@@ -1,2 +1,7 @@
-const supabaseUrl = '';
-const supabaseKey = '';
+const supabaseUrl = String.fromEnvironment(
+  'SUPABASE_URL',
+);
+
+const supabaseKey = String.fromEnvironment(
+  'SUPABASE_ANON_KEY',
+);


### PR DESCRIPTION
## Summary
- Replace hardcoded empty Supabase credentials in `config.dart` with `String.fromEnvironment()` so users pass keys via `--dart-define` or `--dart-define-from-file=.env`
- Add graceful error screen when credentials are missing (instead of crashing)
- Update README with clear setup instructions for obtaining and passing Supabase keys

## Test plan
- [ ] `flutter run -d chrome --dart-define=SUPABASE_URL=... --dart-define=SUPABASE_ANON_KEY=...` connects to Supabase
- [ ] `flutter run -d chrome` without keys shows the error screen with instructions
- [ ] `flutter run -d chrome --dart-define-from-file=.env` works with a local .env file
- [ ] `flutter analyze` passes with no issues

Closes ta-056

🤖 Generated with [Claude Code](https://claude.com/claude-code)